### PR TITLE
Render frame borders without requiring correct emoji rendering

### DIFF
--- a/lib/dev/ui/ansi.rb
+++ b/lib/dev/ui/ansi.rb
@@ -62,6 +62,10 @@ module Dev
         control(n.to_s, 'D')
       end
 
+      def self.cursor_horizontal_absolute(n = 1)
+        control(n.to_s, 'G')
+      end
+
       # Cursor Visibility
 
       def self.show_cursor

--- a/lib/dev/ui/frame.rb
+++ b/lib/dev/ui/frame.rb
@@ -130,24 +130,40 @@ module Dev
             prefix << ' ' << text << ' '
           end
 
+          termwidth = Dev::UI::Terminal.width
+
           suffix = String.new
           if right_text
-            suffix << ' ' << right_text << ' ' << color.code << (Dev::UI::Box::Heavy::HORZ * 2)
+            suffix << ' ' << right_text << ' '
           end
 
-          textwidth = Dev::UI::ANSI.printing_width(prefix + suffix)
-          termwidth = Dev::UI::Terminal.width
-          termwidth = 30 if termwidth < 30
+          suffix_width = Dev::UI::ANSI.printing_width(suffix)
+          suffix_end   = termwidth - 2
+          suffix_start = suffix_end - suffix_width
 
-          if textwidth > termwidth
+          prefix_width = Dev::UI::ANSI.printing_width(prefix)
+          prefix_start = 0
+          prefix_end   = prefix_start + prefix_width
+
+          if prefix_end > suffix_start
             suffix = ''
-            prefix = prefix[0...termwidth]
-            textwidth = termwidth
+            # if prefix_end > termwidth
+            # we *could* truncate it, but let's just let it overflow to the
+            # next line and call it poor usage of this API.
           end
-          padwidth = termwidth - textwidth
-          pad = Dev::UI::Box::Heavy::HORZ * padwidth
 
-          prefix + color.code + pad + suffix + Dev::UI::Color::RESET.code + "\n"
+          o = String.new
+
+          o << color.code
+          o << Dev::UI::Box::Heavy::HORZ * termwidth # draw a full line
+          o << Dev::UI::ANSI.cursor_horizontal_absolute(1 + prefix_start)
+          o << prefix
+          o << Dev::UI::ANSI.cursor_horizontal_absolute(1 + suffix_start)
+          o << suffix
+          o << Dev::UI::Color::RESET.code
+          o << "\n"
+
+          o
         end
 
         module FrameStack

--- a/test/dev/ui/spinner_test.rb
+++ b/test/dev/ui/spinner_test.rb
@@ -46,7 +46,7 @@ module Dev
           /┃ \(empty\)/,
           /┣━━ STDERR/,
           /┃ not empty/,
-          /┗━━━━━/
+          /┗━━/
         )
       end
 
@@ -63,7 +63,7 @@ module Dev
         # Assert all lines are matched
         lines.each do |l|
           # strip ANSI colour code stuff
-          line = l.dup.gsub(/\x1b\[[\d;]+m/, '')
+          line = Dev::UI::ANSI.strip_codes(l)
           assert patterns.any? { |p| line.match(p) }, "Nothing matched the line #{line}"
         end
 


### PR DESCRIPTION
Tmux doesn't print characters at the correct width. This got especially
noticable with our three-codepoint-with-joiner mascot emoji.

Frame borders are now rendered by:

  1. Drawing a line across the screen
  2. Rewinding to the start of line and writing the prefix
  3. Seeking to near the end of the line and writing the suffix