### PR TITLE
Allow SpinGroup tasks to report failure by returning special symbol

### DIFF
--- a/lib/dev/ui/spinner.rb
+++ b/lib/dev/ui/spinner.rb
@@ -4,6 +4,7 @@ module Dev
   module UI
     module Spinner
       PERIOD = 0.1 # seconds
+      TASK_FAILED = :task_failed
 
       begin
         runes = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
@@ -54,6 +55,7 @@ module Dev
             begin
               status = @thread.join.status
               @success = (status == false)
+              @success = false if @thread.value == :task_failed
             rescue => exc
               @exception = exc
               @success = false

--- a/test/dev/ui/spinner_test.rb
+++ b/test/dev/ui/spinner_test.rb
@@ -50,7 +50,7 @@ module Dev
         )
       end
 
-      def test_spinner_error
+      def test_spinner_task_error_through_raising_exception
         out, err = capture_io do
           Dev::UI::StdoutRouter.ensure_activated
           Dev::UI::Spinner.spin('broken') do
@@ -76,6 +76,27 @@ module Dev
           /┣━━ STDERR/,
           /┃ not empty/,
           /┗━━/
+        )
+      end
+
+      def test_spinner_task_error_through_returning_error
+        out, err = capture_io do
+          Dev::UI::StdoutRouter.ensure_activated
+          Dev::UI::Spinner.spin('broken') do
+            $stderr.puts 'not empty'
+            Dev::UI::Spinner::TASK_FAILED
+          end
+        end
+        match_lines(
+          out,
+          /⠋ broken/,
+          /✗/,
+          /┏━━ Task Failed: broken/,
+          /┣━━ STDOUT/,
+          /┃ \(empty\)/,
+          /┣━━ STDERR/,
+          /┃ not empty/,
+          /┗━━/,
         )
       end
 


### PR DESCRIPTION
At the moment, the only way a SpinGroup task can report failure is by
raising an excepting. Since SpinGroup generates a backtrace from the
exception, task failures are very noisy.

This PR allows tasks to return a special symbol `:task_failed` to indicate
to the SpinGroup that it failed. During debrief, SpinGroup doesn't generate
a backtrace for these kind of failure.