### PR TITLE
Render progress bar as spaces instead of blocks

### DIFF
--- a/lib/dev/ui/progress.rb
+++ b/lib/dev/ui/progress.rb
@@ -3,8 +3,8 @@ require 'dev/ui'
 module Dev
   module UI
     class Progress
-      FILLED_BAR = Dev::UI::Glyph.new("◾", 0x2588, Color::CYAN)
-      UNFILLED_BAR = Dev::UI::Glyph.new("◽", 0x2588, Color::WHITE)
+      FILLED_BAR = "\e[46m" # cyan bg
+      UNFILLED_BAR = "\e[1;47m" # bright white bg
 
       # Set the percent to X
       # Dev::UI::Progress.progress do |bar|
@@ -55,9 +55,9 @@ module Dev
         unfilled = workable_width - filled
 
         Dev::UI.resolve_text [
-          (FILLED_BAR.to_s * filled),
-          (UNFILLED_BAR.to_s * unfilled),
-          suffix
+          FILLED_BAR + ' ' * filled,
+          UNFILLED_BAR + ' ' * unfilled,
+          Dev::UI::Color::RESET.code + suffix
         ].join
       end
     end

--- a/test/dev/ui/progress_test.rb
+++ b/test/dev/ui/progress_test.rb
@@ -27,10 +27,7 @@ module Dev
       end
 
       def assert_bar(percent: nil, set_percent: nil, expected_filled: 0, expected_unfilled: 0, suffix: '')
-        expected_bar = "\e[0m" +
-          (Progress::FILLED_BAR.to_s * expected_filled) +
-          (Progress::UNFILLED_BAR.to_s * expected_unfilled) +
-          suffix
+        expected_bar = "\e[0m\e[46m#{' ' * expected_filled}\e[1;47m#{' ' * expected_unfilled}\e[0m#{suffix}"
 
         params = {}
         params[:percent] = percent if percent


### PR DESCRIPTION
@jules2689 @alanwushopify 

I think this will look better on some terminals -- also it prints a lot fewer formatting codes, which should speed up rendering a bit.