### PR TITLE
reopen tty after interactive prompt runs

### DIFF
--- a/lib/dev/ui/interactive_prompt.rb
+++ b/lib/dev/ui/interactive_prompt.rb
@@ -36,6 +36,7 @@ module Dev
           print(ANSI.show_cursor)
           puts(ANSI.previous_line + ANSI.end_of_line)
         end
+        $stdin.reopen('/dev/tty')
       end
 
       private


### PR DESCRIPTION
Commands in dev that use` interactive_prompt` and then `system_sudo` will break as stdin changes device type somewhere in the process.